### PR TITLE
Protect against missing view

### DIFF
--- a/HideSidebarWhenNotFocussed.py
+++ b/HideSidebarWhenNotFocussed.py
@@ -4,9 +4,10 @@ PLUGIN_NAME = 'HideSidebarWhenNotFocussed'
 
 class HideSidebarWhenNotFocussedListener(sublime_plugin.EventListener):
   def on_activated(self, view):
-    if len(view.window().views()) == 0:
-        # no open views, so show sidebar
-        view.window().set_sidebar_visible(True)
-    elif view.window().is_sidebar_visible():
-        # sidebar is visible, so hide it
-        view.window().set_sidebar_visible(False)
+    if view:
+        if len(view.window().views()) == 0:
+            # no open views, so show sidebar
+            view.window().set_sidebar_visible(True)
+        elif view.window().is_sidebar_visible():
+            # sidebar is visible, so hide it
+            view.window().set_sidebar_visible(False)


### PR DESCRIPTION
There is a potential error when view is none.
I saw error messages in sublime's console log pointing to such event, albeit I have not been able to reproduce it.
Importantly this error did not cause any noticeable interference with either Sublime's user interface nor the plugin itself.

Still I introduced a single line of code which should prevent this error from now on.
As it is better being safe than being sorry.